### PR TITLE
chore: add EOL for staking command

### DIFF
--- a/src/command/staking.ts
+++ b/src/command/staking.ts
@@ -49,6 +49,7 @@ const stakingCommand: CommandModule = {
         )
         log(`PERP staking reward vesting allowance: ${commify(toNumber(allowanceVesting))}`)
         log(`PERP staking reward noVesting allowance: ${commify(toNumber(allowanceNoVesting))}`)
+        log(``)
     },
 }
 


### PR DESCRIPTION
This EOL is missing for Bot Logger.